### PR TITLE
가위바위보 게임 [STEP 1] gogochang

### DIFF
--- a/RockPaperScissors/GameResult.swift
+++ b/RockPaperScissors/GameResult.swift
@@ -14,7 +14,7 @@ enum GameResult: Int {
     case playing
     case ready
     
-    var result: String {
+    var label: String {
         switch self {
         case .win:
             return "승리"
@@ -28,12 +28,4 @@ enum GameResult: Int {
             return "준비"
         }
     }
-}
-
-enum GameState {
-    static let GAME_WIN = 0
-    static let GAME_LOSE = 1
-    static let GAME_DRAW = 2
-    static let GAME_PLAYING = 3
-    static let GAME_READY = 4
 }

--- a/RockPaperScissors/GameResult.swift
+++ b/RockPaperScissors/GameResult.swift
@@ -1,0 +1,39 @@
+//
+//  GameResult.swift
+//  RockPaperScissors
+//
+//  Created by 김창규 on 2/6/24.
+//
+
+import Foundation
+
+enum GameResult: Int {
+    case win = 0
+    case lose
+    case draw
+    case playing
+    case ready
+    
+    var result: String {
+        switch self {
+        case .win:
+            return "승리"
+        case .lose:
+            return "패배"
+        case .draw:
+            return "무승부"
+        case .playing:
+            return "게임중"
+        case .ready:
+            return "준비"
+        }
+    }
+}
+
+enum GameState {
+    static let GAME_WIN = 0
+    static let GAME_LOSE = 1
+    static let GAME_DRAW = 2
+    static let GAME_PLAYING = 3
+    static let GAME_READY = 4
+}

--- a/RockPaperScissors/HandGame.swift
+++ b/RockPaperScissors/HandGame.swift
@@ -31,9 +31,9 @@ extension HandGame {
     var totalScore: Int { score.totalScore }
     
     var gameResult: GameResult? { score.gameResult }
-    var resultLabel: String? { gameResult?.result }
+    var resultLabel: String? { gameResult?.label }
     
-    var currentWinLose: String { score.correuntWinlose }
+    var currentWinLose: String { score.currentWinlose }
     
     var gameFinished: Bool { score.totalScore >= score.limit }
     

--- a/RockPaperScissors/HandGame.swift
+++ b/RockPaperScissors/HandGame.swift
@@ -1,0 +1,71 @@
+//
+//  HandGame.swift
+//  RockPaperScissors
+//
+//  Created by 김창규 on 2/6/24.
+//
+
+import Foundation
+
+enum HandType {
+    case left
+    case right
+}
+
+protocol HandGame: AnyObject {
+    var leftHand: HandStrategy { get }
+    var rightHand: HandStrategy { get }
+    var score: Score { get set }
+    var myHand: HandType { get }
+}
+
+extension HandGame {
+    var leftHand: String { leftHand.randomHand }
+    var rightHand: String { rightHand.randomHand }
+    var leftName: String { leftHand.name }
+    var rightName: String { rightHand.name }
+    
+    var winCount: Int { score.winCount }
+    var loseCount: Int { score.loseCount }
+    var drawCount: Int { score.drawCount }
+    var totalScore: Int { score.totalScore }
+    
+    var gameResult: GameResult? { score.gameResult }
+    var resultLabel: String? { gameResult?.result }
+    
+    var currentWinLose: String { score.correuntWinlose }
+    
+    var gameFinished: Bool { score.totalScore >= score.limit }
+    
+    func determineWinner(left: String?, right: String?) {
+        let handComparison = myHand == .left ? (right, left) : (left, right)
+        switch handComparison {
+        case ("✌️","✊"),("🖐️","✌️"),("✊","🖐️"):
+            score.upWinCount()
+        case ("✊","✌️"),("✌️","🖐️"),("🖐️","✊"):
+            score.upLoseCount()
+        case ("✊","✊"),("✌️","✌️"),("🖐️","🖐️"):
+            score.upDrawCount()
+        default:
+            return
+        }
+    }
+    
+    func resetScore() {
+        score.resetScore()
+    }
+}
+
+final class RPSGame: HandGame {
+    var leftHand: HandStrategy
+    var rightHand: HandStrategy
+    var score: Score
+    var myHand: HandType
+    
+    init(leftHand: HandStrategy, rightHand: HandStrategy, score: Score, myHand: HandType) {
+        self.leftHand = leftHand
+        self.rightHand = rightHand
+        self.score = score
+        self.myHand = myHand
+    }
+}

--- a/RockPaperScissors/HandStrategy.swift
+++ b/RockPaperScissors/HandStrategy.swift
@@ -1,0 +1,26 @@
+//
+//  HandStrategy.swift
+//  RockPaperScissors
+//
+//  Created by 김창규 on 2/6/24.
+//
+
+import Foundation
+
+protocol HandStrategy {
+    var name: String { get }
+}
+
+extension HandStrategy {
+    var randomHand: String {
+        return ["✊","✌️","🖐️"].randomElement() ?? ""
+    }
+}
+
+struct ComputerHand: HandStrategy {
+    private(set) var name: String
+}
+
+struct UserHand: HandStrategy {
+    private(set) var name: String
+}

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -7,7 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		953DCDAE2B726A7000B4E66E /* HandStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953DCDAD2B726A7000B4E66E /* HandStrategy.swift */; };
+		953DCDB02B726A8900B4E66E /* GameResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953DCDAF2B726A8900B4E66E /* GameResult.swift */; };
+		953DCDB22B726AA600B4E66E /* HandGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953DCDB12B726AA600B4E66E /* HandGame.swift */; };
 		95A3F8992B71281F00842E4A /* RockPaperScissorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A3F8982B71281F00842E4A /* RockPaperScissorsTests.swift */; };
+		95F06F0D2B728EC700133D0D /* Score.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F06F0C2B728EC700133D0D /* Score.swift */; };
 		C784841D2B5E48E300FBF8B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784841C2B5E48E300FBF8B4 /* AppDelegate.swift */; };
 		C784841F2B5E48E300FBF8B4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784841E2B5E48E300FBF8B4 /* SceneDelegate.swift */; };
 		C78484212B5E48E300FBF8B4 /* GameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78484202B5E48E300FBF8B4 /* GameViewController.swift */; };
@@ -28,8 +32,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		953DCDAD2B726A7000B4E66E /* HandStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandStrategy.swift; sourceTree = "<group>"; };
+		953DCDAF2B726A8900B4E66E /* GameResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResult.swift; sourceTree = "<group>"; };
+		953DCDB12B726AA600B4E66E /* HandGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandGame.swift; sourceTree = "<group>"; };
 		95A3F8962B71281F00842E4A /* RockPaperScissorsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RockPaperScissorsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		95A3F8982B71281F00842E4A /* RockPaperScissorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissorsTests.swift; sourceTree = "<group>"; };
+		95F06F0C2B728EC700133D0D /* Score.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Score.swift; sourceTree = "<group>"; };
 		C78484192B5E48E300FBF8B4 /* RockPaperScissors.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RockPaperScissors.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C784841C2B5E48E300FBF8B4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C784841E2B5E48E300FBF8B4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -70,6 +78,10 @@
 		C78484102B5E48E300FBF8B4 = {
 			isa = PBXGroup;
 			children = (
+				95F06F0C2B728EC700133D0D /* Score.swift */,
+				953DCDB12B726AA600B4E66E /* HandGame.swift */,
+				953DCDAF2B726A8900B4E66E /* GameResult.swift */,
+				953DCDAD2B726A7000B4E66E /* HandStrategy.swift */,
 				C784841B2B5E48E300FBF8B4 /* RockPaperScissors */,
 				95A3F8972B71281F00842E4A /* RockPaperScissorsTests */,
 				C784841A2B5E48E300FBF8B4 /* Products */,
@@ -209,7 +221,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				953DCDAE2B726A7000B4E66E /* HandStrategy.swift in Sources */,
 				C78484212B5E48E300FBF8B4 /* GameViewController.swift in Sources */,
+				95F06F0D2B728EC700133D0D /* Score.swift in Sources */,
+				953DCDB22B726AA600B4E66E /* HandGame.swift in Sources */,
+				953DCDB02B726A8900B4E66E /* GameResult.swift in Sources */,
 				C784841D2B5E48E300FBF8B4 /* AppDelegate.swift in Sources */,
 				C78484642B6A32E500FBF8B4 /* GameView.swift in Sources */,
 				C784841F2B5E48E300FBF8B4 /* SceneDelegate.swift in Sources */,

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		95A3F8992B71281F00842E4A /* RockPaperScissorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A3F8982B71281F00842E4A /* RockPaperScissorsTests.swift */; };
 		C784841D2B5E48E300FBF8B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784841C2B5E48E300FBF8B4 /* AppDelegate.swift */; };
 		C784841F2B5E48E300FBF8B4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784841E2B5E48E300FBF8B4 /* SceneDelegate.swift */; };
 		C78484212B5E48E300FBF8B4 /* GameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78484202B5E48E300FBF8B4 /* GameViewController.swift */; };
@@ -16,7 +17,19 @@
 		C78484642B6A32E500FBF8B4 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78484632B6A32E500FBF8B4 /* GameView.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		95A3F89A2B71281F00842E4A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C78484112B5E48E300FBF8B4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C78484182B5E48E300FBF8B4;
+			remoteInfo = RockPaperScissors;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		95A3F8962B71281F00842E4A /* RockPaperScissorsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RockPaperScissorsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		95A3F8982B71281F00842E4A /* RockPaperScissorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissorsTests.swift; sourceTree = "<group>"; };
 		C78484192B5E48E300FBF8B4 /* RockPaperScissors.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RockPaperScissors.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C784841C2B5E48E300FBF8B4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C784841E2B5E48E300FBF8B4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -29,6 +42,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		95A3F8932B71281F00842E4A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C78484162B5E48E300FBF8B4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -39,10 +59,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		95A3F8972B71281F00842E4A /* RockPaperScissorsTests */ = {
+			isa = PBXGroup;
+			children = (
+				95A3F8982B71281F00842E4A /* RockPaperScissorsTests.swift */,
+			);
+			path = RockPaperScissorsTests;
+			sourceTree = "<group>";
+		};
 		C78484102B5E48E300FBF8B4 = {
 			isa = PBXGroup;
 			children = (
 				C784841B2B5E48E300FBF8B4 /* RockPaperScissors */,
+				95A3F8972B71281F00842E4A /* RockPaperScissorsTests */,
 				C784841A2B5E48E300FBF8B4 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -51,6 +80,7 @@
 			isa = PBXGroup;
 			children = (
 				C78484192B5E48E300FBF8B4 /* RockPaperScissors.app */,
+				95A3F8962B71281F00842E4A /* RockPaperScissorsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -73,6 +103,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		95A3F8952B71281F00842E4A /* RockPaperScissorsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 95A3F89E2B71281F00842E4A /* Build configuration list for PBXNativeTarget "RockPaperScissorsTests" */;
+			buildPhases = (
+				95A3F8922B71281F00842E4A /* Sources */,
+				95A3F8932B71281F00842E4A /* Frameworks */,
+				95A3F8942B71281F00842E4A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				95A3F89B2B71281F00842E4A /* PBXTargetDependency */,
+			);
+			name = RockPaperScissorsTests;
+			productName = RockPaperScissorsTests;
+			productReference = 95A3F8962B71281F00842E4A /* RockPaperScissorsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C78484182B5E48E300FBF8B4 /* RockPaperScissors */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C784842D2B5E48E400FBF8B4 /* Build configuration list for PBXNativeTarget "RockPaperScissors" */;
@@ -97,9 +145,13 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1500;
+				LastSwiftUpdateCheck = 1520;
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
+					95A3F8952B71281F00842E4A = {
+						CreatedOnToolsVersion = 15.2;
+						TestTargetID = C78484182B5E48E300FBF8B4;
+					};
 					C78484182B5E48E300FBF8B4 = {
 						CreatedOnToolsVersion = 15.0.1;
 					};
@@ -119,11 +171,19 @@
 			projectRoot = "";
 			targets = (
 				C78484182B5E48E300FBF8B4 /* RockPaperScissors */,
+				95A3F8952B71281F00842E4A /* RockPaperScissorsTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		95A3F8942B71281F00842E4A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C78484172B5E48E300FBF8B4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -137,6 +197,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		95A3F8922B71281F00842E4A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				95A3F8992B71281F00842E4A /* RockPaperScissorsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C78484152B5E48E300FBF8B4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -149,6 +217,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		95A3F89B2B71281F00842E4A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C78484182B5E48E300FBF8B4 /* RockPaperScissors */;
+			targetProxy = 95A3F89A2B71281F00842E4A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C78484222B5E48E300FBF8B4 /* Main.storyboard */ = {
@@ -170,6 +246,50 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		95A3F89C2B71281F00842E4A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = K988K33886;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.changgyukim.RockPaperScissorsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RockPaperScissors.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RockPaperScissors";
+			};
+			name = Debug;
+		};
+		95A3F89D2B71281F00842E4A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = K988K33886;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.changgyukim.RockPaperScissorsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RockPaperScissors.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RockPaperScissors";
+			};
+			name = Release;
+		};
 		C784842B2B5E48E400FBF8B4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -344,6 +464,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		95A3F89E2B71281F00842E4A /* Build configuration list for PBXNativeTarget "RockPaperScissorsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				95A3F89C2B71281F00842E4A /* Debug */,
+				95A3F89D2B71281F00842E4A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C78484142B5E48E300FBF8B4 /* Build configuration list for PBXProject "RockPaperScissors" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/RockPaperScissors/RockPaperScissors/GameViewController.swift
+++ b/RockPaperScissors/RockPaperScissors/GameViewController.swift
@@ -11,18 +11,19 @@ class GameViewController: UIViewController {
     
     override func loadView() {
         view = GameView(
-            leftHandGame: LeftHandGame(
-                handStrategy: ComputerHand(
+            rpsGame: RPSGame(
+                leftHand: ComputerHand(
+                    name: "컴퓨터"),
+                rightHand: UserHand(
+                    name: "나"),
+                score: Score(
                     winCount: 0,
                     loseCount: 0,
-                    drawCount: 0),
-                gameResult: .ready),
-            rightHandGame: RightHandGame(
-                handStrategy: UserHand(
-                    winCount: 0,
-                    loseCount: 0,
-                    drawCount: 0),
-                gameResult: .ready))
+                    drawCount: 0,
+                    limit: 3),
+                myHand: .right
+            )
+        )    
     }
     
     override func viewDidLoad() {

--- a/RockPaperScissors/RockPaperScissors/GameViewController.swift
+++ b/RockPaperScissors/RockPaperScissors/GameViewController.swift
@@ -1,23 +1,35 @@
 //
 //  RockPaperScissors - ViewController.swift
-//  Created by yagom. 
+//  Created by yagom.
 //  Copyright © yagom. All rights reserved.
-// 
+//
 
 import UIKit
 
 class GameViewController: UIViewController {
-
+    
     
     override func loadView() {
-        view = GameView()
+        view = GameView(
+            leftHandGame: LeftHandGame(
+                handStrategy: ComputerHand(
+                    winCount: 0,
+                    loseCount: 0,
+                    drawCount: 0),
+                gameResult: .ready),
+            rightHandGame: RightHandGame(
+                handStrategy: UserHand(
+                    winCount: 0,
+                    loseCount: 0,
+                    drawCount: 0),
+                gameResult: .ready))
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
     }
-
-
+    
+    
 }
 

--- a/RockPaperScissors/RockPaperScissorsTests/RockPaperScissorsTests.swift
+++ b/RockPaperScissors/RockPaperScissorsTests/RockPaperScissorsTests.swift
@@ -1,0 +1,121 @@
+//
+//  RockPaperScissorsTests.swift
+//  RockPaperScissorsTests
+//
+//  Created by 김창규 on 2/5/24.
+//
+
+import XCTest
+@testable import RockPaperScissors
+
+final class RockPaperScissorsTests: XCTestCase {
+
+    var sutLeft: HandGame!
+    var sutRight: HandGame!
+    
+    override func setUpWithError() throws {
+        sutLeft = LeftHandGame(
+            handStrategy: UserHand(
+                winCount: 0,
+                loseCount: 0,
+                drawCount: 0),
+            gameResult: .ready)
+        
+        sutRight = RightHandGame(
+            handStrategy: UserHand(
+                winCount: 0,
+                loseCount: 0,
+                drawCount: 0),
+            gameResult: .ready)
+    }
+
+    override func tearDownWithError() throws {
+        sutLeft = nil
+        sutRight = nil
+    }
+
+    //MARK: - Rock
+    func test_determineWinner에_rock_paper_입력하면_승리한다() {
+        //given, when
+        sutLeft.determineWinner(left: "✊", right: "🖐️")
+        sutRight.determineWinner(left: "✊", right: "🖐️")
+        //then
+        XCTAssertEqual(sutLeft.gameResult, .lose)
+        XCTAssertEqual(sutRight.gameResult, .win)
+    }
+    
+    func test_determineWinner에_rock_rock_입력하면_무승부한다() {
+        //given, when
+        sutLeft.determineWinner(left: "✊", right: "✊")
+        sutRight.determineWinner(left: "✊", right: "✊")
+        //then
+        XCTAssertEqual(sutLeft.gameResult, .draw)
+        XCTAssertEqual(sutRight.gameResult, .draw)
+    }
+    
+    func test_determineWinner에_rock_scissor_입력하면_패배한다() {
+        //given, when
+        sutLeft.determineWinner(left: "✊", right: "✌️")
+        sutRight.determineWinner(left: "✊", right: "✌️")
+        //then
+        XCTAssertEqual(sutLeft.gameResult, .win)
+        XCTAssertEqual(sutRight.gameResult, .lose)
+    }
+
+    //MARK: - Paper
+    func test_determineWinner에_paper_paper_입력하면_무승부한다() {
+        //given, when
+        sutLeft.determineWinner(left: "🖐️", right: "🖐️")
+        sutRight.determineWinner(left: "🖐️", right: "🖐️")
+        //then
+        XCTAssertEqual(sutLeft.gameResult, .draw)
+        XCTAssertEqual(sutRight.gameResult, .draw)
+    }
+    
+    func test_determineWinner에_paper_rock_입력하면_패배한다() {
+        //given, when
+        sutLeft.determineWinner(left: "🖐️", right: "✊")
+        sutRight.determineWinner(left: "🖐️", right: "✊")
+        //then
+        XCTAssertEqual(sutLeft.gameResult, .win)
+        XCTAssertEqual(sutRight.gameResult, .lose)
+    }
+    
+    func test_determineWinner에_paper_scissor_입력하면_승리한다() {
+        //given, when
+        sutLeft.determineWinner(left: "🖐️", right: "✌️")
+        sutRight.determineWinner(left: "🖐️", right: "✌️")
+        //then
+        XCTAssertEqual(sutLeft.gameResult, .lose)
+        XCTAssertEqual(sutRight.gameResult, .win)
+    }
+    
+    //MARK: - Scissor
+    func test_determineWinner에_scissor_paper_입력하면_패배한다() {
+        //given, when
+        sutLeft.determineWinner(left: "✌️", right: "🖐️")
+        sutRight.determineWinner(left: "✌️", right: "🖐️")
+        //then
+        XCTAssertEqual(sutLeft.gameResult, .win)
+        XCTAssertEqual(sutRight.gameResult, .lose)
+    }
+    
+    func test_determineWinner에_scissor_rock_입력하면_승리한다() {
+        //given, when
+        sutLeft.determineWinner(left: "✌️", right: "✊")
+        sutRight.determineWinner(left: "✌️", right: "✊")
+        //then
+        XCTAssertEqual(sutLeft.gameResult, .lose)
+        XCTAssertEqual(sutRight.gameResult, .win)
+    }
+    
+    func test_determineWinner에_scissor_scissor_입력하면_무승부한다() {
+        //given, when
+        sutLeft.determineWinner(left: "✌️", right: "✌️")
+        sutRight.determineWinner(left: "✌️", right: "✌️")
+        //then
+        XCTAssertEqual(sutLeft.gameResult, .draw)
+        XCTAssertEqual(sutRight.gameResult, .draw)
+    }
+    
+}

--- a/RockPaperScissors/RockPaperScissorsTests/RockPaperScissorsTests.swift
+++ b/RockPaperScissors/RockPaperScissorsTests/RockPaperScissorsTests.swift
@@ -9,113 +9,177 @@ import XCTest
 @testable import RockPaperScissors
 
 final class RockPaperScissorsTests: XCTestCase {
-
-    var sutLeft: HandGame!
-    var sutRight: HandGame!
+    var sut: RPSGame!
     
     override func setUpWithError() throws {
-        sutLeft = LeftHandGame(
-            handStrategy: UserHand(
-                winCount: 0,
-                loseCount: 0,
-                drawCount: 0),
-            gameResult: .ready)
         
-        sutRight = RightHandGame(
-            handStrategy: UserHand(
+        sut = RPSGame(
+            leftHand: ComputerHand(
+                name: "컴퓨터"),
+            rightHand: UserHand(
+                name: "나"),
+            score: Score(
                 winCount: 0,
                 loseCount: 0,
-                drawCount: 0),
-            gameResult: .ready)
+                drawCount: 0,
+                limit: 3),
+            myHand: .right)
     }
-
+    
     override func tearDownWithError() throws {
-        sutLeft = nil
-        sutRight = nil
+        sut = nil
     }
-
+    
     //MARK: - Rock
-    func test_determineWinner에_rock_paper_입력하면_승리한다() {
+    func test_determineWinner에_rock_paper_입력하면_winCount가_1이다() {
         //given, when
-        sutLeft.determineWinner(left: "✊", right: "🖐️")
-        sutRight.determineWinner(left: "✊", right: "🖐️")
+        sut.determineWinner(left: "✊", right: "🖐️")
         //then
-        XCTAssertEqual(sutLeft.gameResult, .lose)
-        XCTAssertEqual(sutRight.gameResult, .win)
+        XCTAssertEqual(sut.winCount, 1)
     }
     
-    func test_determineWinner에_rock_rock_입력하면_무승부한다() {
+    func test_determineWinner에_rock_rock_입력하면_drawCount가_1이다() {
         //given, when
-        sutLeft.determineWinner(left: "✊", right: "✊")
-        sutRight.determineWinner(left: "✊", right: "✊")
+        sut.determineWinner(left: "✊", right: "✊")
+        
         //then
-        XCTAssertEqual(sutLeft.gameResult, .draw)
-        XCTAssertEqual(sutRight.gameResult, .draw)
+        XCTAssertEqual(sut.drawCount, 1)
     }
     
-    func test_determineWinner에_rock_scissor_입력하면_패배한다() {
+    func test_determineWinner에_rock_scissor_입력하면_loseCount가_1이다() {
         //given, when
-        sutLeft.determineWinner(left: "✊", right: "✌️")
-        sutRight.determineWinner(left: "✊", right: "✌️")
+        sut.determineWinner(left: "✊", right: "✌️")
+        
         //then
-        XCTAssertEqual(sutLeft.gameResult, .win)
-        XCTAssertEqual(sutRight.gameResult, .lose)
+        XCTAssertEqual(sut.loseCount, 1)
     }
-
+    
     //MARK: - Paper
-    func test_determineWinner에_paper_paper_입력하면_무승부한다() {
+    func test_determineWinner에_paper_paper_입력하면_drawCount가_1이다() {
         //given, when
-        sutLeft.determineWinner(left: "🖐️", right: "🖐️")
-        sutRight.determineWinner(left: "🖐️", right: "🖐️")
+        sut.determineWinner(left: "🖐️", right: "🖐️")
+        
         //then
-        XCTAssertEqual(sutLeft.gameResult, .draw)
-        XCTAssertEqual(sutRight.gameResult, .draw)
+        XCTAssertEqual(sut.drawCount, 1)
     }
     
-    func test_determineWinner에_paper_rock_입력하면_패배한다() {
+    func test_determineWinner에_paper_rock_입력하면_loseCount가_1이다() {
         //given, when
-        sutLeft.determineWinner(left: "🖐️", right: "✊")
-        sutRight.determineWinner(left: "🖐️", right: "✊")
+        sut.determineWinner(left: "🖐️", right: "✊")
+        
         //then
-        XCTAssertEqual(sutLeft.gameResult, .win)
-        XCTAssertEqual(sutRight.gameResult, .lose)
+        XCTAssertEqual(sut.loseCount, 1)
     }
     
-    func test_determineWinner에_paper_scissor_입력하면_승리한다() {
+    func test_determineWinner에_paper_scissor_입력하면_winCount가_1이다() {
         //given, when
-        sutLeft.determineWinner(left: "🖐️", right: "✌️")
-        sutRight.determineWinner(left: "🖐️", right: "✌️")
+        sut.determineWinner(left: "🖐️", right: "✌️")
+        
         //then
-        XCTAssertEqual(sutLeft.gameResult, .lose)
-        XCTAssertEqual(sutRight.gameResult, .win)
+        XCTAssertEqual(sut.winCount, 1)
     }
     
     //MARK: - Scissor
-    func test_determineWinner에_scissor_paper_입력하면_패배한다() {
+    func test_determineWinner에_scissor_paper_입력하면_loseCount가_1이다() {
         //given, when
-        sutLeft.determineWinner(left: "✌️", right: "🖐️")
-        sutRight.determineWinner(left: "✌️", right: "🖐️")
+        sut.determineWinner(left: "✌️", right: "🖐️")
+        
         //then
-        XCTAssertEqual(sutLeft.gameResult, .win)
-        XCTAssertEqual(sutRight.gameResult, .lose)
+        XCTAssertEqual(sut.loseCount, 1)
     }
     
-    func test_determineWinner에_scissor_rock_입력하면_승리한다() {
+    func test_determineWinner에_scissor_rock_입력하면_winCount가_1이다() {
         //given, when
-        sutLeft.determineWinner(left: "✌️", right: "✊")
-        sutRight.determineWinner(left: "✌️", right: "✊")
+        sut.determineWinner(left: "✌️", right: "✊")
+        
         //then
-        XCTAssertEqual(sutLeft.gameResult, .lose)
-        XCTAssertEqual(sutRight.gameResult, .win)
+        XCTAssertEqual(sut.winCount, 1)
     }
     
-    func test_determineWinner에_scissor_scissor_입력하면_무승부한다() {
+    func test_determineWinner에_scissor_scissor_입력하면_drawCount가_1이다() {
         //given, when
-        sutLeft.determineWinner(left: "✌️", right: "✌️")
-        sutRight.determineWinner(left: "✌️", right: "✌️")
+        sut.determineWinner(left: "✌️", right: "✌️")
+        
         //then
-        XCTAssertEqual(sutLeft.gameResult, .draw)
-        XCTAssertEqual(sutRight.gameResult, .draw)
+        XCTAssertEqual(sut.drawCount, 1)
     }
+    
+    
+    //MARK: - 삼세판 기능 TDD
+    func test_determineWinner를_3번_호출하면_게임횟수의_totalScoure가_3이다() {
+        //given, when
+        sut.determineWinner(left: "✌️", right: "✌️")
+        sut.determineWinner(left: "✌️", right: "✌️")
+        sut.determineWinner(left: "✌️", right: "✌️")
+        
+        //then
+        XCTAssertEqual(sut.totalScore, 3)
+    }
+    
+    func test_determineWinner를_3번_호출하면_gameFinished가_참이다() {
+        //given, when
+        sut.determineWinner(left: "✌️", right: "✌️")
+        sut.determineWinner(left: "✌️", right: "✌️")
+        sut.determineWinner(left: "✌️", right: "✌️")
+        
+        //then
+        XCTAssertEqual(sut.gameFinished, true)
+    }
+    
+    func test_determineWinner를_1번_호출하면_gameFinished가_거짓이다() {
+        //given, when
+        sut.determineWinner(left: "✌️", right: "✌️")
+        
+        //then
+        XCTAssertEqual(sut.gameFinished, false)
+        XCTAssertEqual(sut.gameResult, .playing)
+    }
+    
+    func test_determinWinner에서_승리3번_패배0번이면_gameResult가_win타입이다() {
+        //given, when
+        sut.determineWinner(left: "✌️", right: "✊")
+        sut.determineWinner(left: "🖐️", right: "✌️")
+        sut.determineWinner(left: "✊", right: "🖐️")
+        
+        //then
+        XCTAssertEqual(sut.gameResult, .win)
+    }
+    
+    func test_determinWinner에서_승리0번_패배3번이면_gameResult가_lose타입이다() {
+        //given, when
+        sut.determineWinner(left: "🖐️", right: "✊")
+        sut.determineWinner(left: "✊", right: "✌️")
+        sut.determineWinner(left: "✌️", right: "🖐️")
+        
+        //then
+        XCTAssertEqual(sut.gameResult, .lose)
+    }
+    
+    func test_determinWinner에서_무승부이면_gameResult가_draw타입이다() {
+        //given, when
+        sut.determineWinner(left: "✊", right: "✊")
+        sut.determineWinner(left: "✌️", right: "✌️")
+        sut.determineWinner(left: "🖐️", right: "🖐️")
+        
+        //then
+        XCTAssertEqual(sut.gameResult, .draw)
+    }
+    
+    //MARK: - 삼세판 끝나고 승패가 갈리면 초기화 하는 기능 TDD
+    func test_resetScore를_호출하면_데이터초기화() {
+        //given, when
+        sut.determineWinner(left: "✊", right: "✊")
+        sut.determineWinner(left: "✌️", right: "✌️")
+        sut.determineWinner(left: "🖐️", right: "🖐️")
+        
+        //when
+        sut.resetScore()
+        
+        XCTAssertEqual(sut.winCount, 0)
+        XCTAssertEqual(sut.loseCount, 0)
+        XCTAssertEqual(sut.drawCount, 0)
+        XCTAssertEqual(sut.gameResult, .ready)
+    }
+    
     
 }

--- a/RockPaperScissors/RockPaperScissorsTests/RockPaperScissorsTests.swift
+++ b/RockPaperScissors/RockPaperScissorsTests/RockPaperScissorsTests.swift
@@ -9,10 +9,10 @@ import XCTest
 @testable import RockPaperScissors
 
 final class RockPaperScissorsTests: XCTestCase {
-    var sut: RPSGame!
+    var sut: RPSGame?
     
     override func setUpWithError() throws {
-        
+        try super.setUpWithError()
         sut = RPSGame(
             leftHand: ComputerHand(
                 name: "컴퓨터"),
@@ -27,158 +27,159 @@ final class RockPaperScissorsTests: XCTestCase {
     }
     
     override func tearDownWithError() throws {
+        try super.tearDownWithError()
         sut = nil
     }
     
     //MARK: - Rock
     func test_determineWinner에_rock_paper_입력하면_winCount가_1이다() {
         //given, when
-        sut.determineWinner(left: "✊", right: "🖐️")
+        sut?.determineWinner(left: "✊", right: "🖐️")
         //then
-        XCTAssertEqual(sut.winCount, 1)
+        XCTAssertEqual(sut?.winCount, 1)
     }
     
     func test_determineWinner에_rock_rock_입력하면_drawCount가_1이다() {
         //given, when
-        sut.determineWinner(left: "✊", right: "✊")
+        sut?.determineWinner(left: "✊", right: "✊")
         
         //then
-        XCTAssertEqual(sut.drawCount, 1)
+        XCTAssertEqual(sut?.drawCount, 1)
     }
     
     func test_determineWinner에_rock_scissor_입력하면_loseCount가_1이다() {
         //given, when
-        sut.determineWinner(left: "✊", right: "✌️")
+        sut?.determineWinner(left: "✊", right: "✌️")
         
         //then
-        XCTAssertEqual(sut.loseCount, 1)
+        XCTAssertEqual(sut?.loseCount, 1)
     }
     
     //MARK: - Paper
     func test_determineWinner에_paper_paper_입력하면_drawCount가_1이다() {
         //given, when
-        sut.determineWinner(left: "🖐️", right: "🖐️")
+        sut?.determineWinner(left: "🖐️", right: "🖐️")
         
         //then
-        XCTAssertEqual(sut.drawCount, 1)
+        XCTAssertEqual(sut?.drawCount, 1)
     }
     
     func test_determineWinner에_paper_rock_입력하면_loseCount가_1이다() {
         //given, when
-        sut.determineWinner(left: "🖐️", right: "✊")
+        sut?.determineWinner(left: "🖐️", right: "✊")
         
         //then
-        XCTAssertEqual(sut.loseCount, 1)
+        XCTAssertEqual(sut?.loseCount, 1)
     }
     
     func test_determineWinner에_paper_scissor_입력하면_winCount가_1이다() {
         //given, when
-        sut.determineWinner(left: "🖐️", right: "✌️")
+        sut?.determineWinner(left: "🖐️", right: "✌️")
         
         //then
-        XCTAssertEqual(sut.winCount, 1)
+        XCTAssertEqual(sut?.winCount, 1)
     }
     
     //MARK: - Scissor
     func test_determineWinner에_scissor_paper_입력하면_loseCount가_1이다() {
         //given, when
-        sut.determineWinner(left: "✌️", right: "🖐️")
+        sut?.determineWinner(left: "✌️", right: "🖐️")
         
         //then
-        XCTAssertEqual(sut.loseCount, 1)
+        XCTAssertEqual(sut?.loseCount, 1)
     }
     
     func test_determineWinner에_scissor_rock_입력하면_winCount가_1이다() {
         //given, when
-        sut.determineWinner(left: "✌️", right: "✊")
+        sut?.determineWinner(left: "✌️", right: "✊")
         
         //then
-        XCTAssertEqual(sut.winCount, 1)
+        XCTAssertEqual(sut?.winCount, 1)
     }
     
     func test_determineWinner에_scissor_scissor_입력하면_drawCount가_1이다() {
         //given, when
-        sut.determineWinner(left: "✌️", right: "✌️")
+        sut?.determineWinner(left: "✌️", right: "✌️")
         
         //then
-        XCTAssertEqual(sut.drawCount, 1)
+        XCTAssertEqual(sut?.drawCount, 1)
     }
     
     
     //MARK: - 삼세판 기능 TDD
     func test_determineWinner를_3번_호출하면_게임횟수의_totalScoure가_3이다() {
         //given, when
-        sut.determineWinner(left: "✌️", right: "✌️")
-        sut.determineWinner(left: "✌️", right: "✌️")
-        sut.determineWinner(left: "✌️", right: "✌️")
+        sut?.determineWinner(left: "✌️", right: "✌️")
+        sut?.determineWinner(left: "✌️", right: "✌️")
+        sut?.determineWinner(left: "✌️", right: "✌️")
         
         //then
-        XCTAssertEqual(sut.totalScore, 3)
+        XCTAssertEqual(sut?.totalScore, 3)
     }
     
     func test_determineWinner를_3번_호출하면_gameFinished가_참이다() {
         //given, when
-        sut.determineWinner(left: "✌️", right: "✌️")
-        sut.determineWinner(left: "✌️", right: "✌️")
-        sut.determineWinner(left: "✌️", right: "✌️")
+        sut?.determineWinner(left: "✌️", right: "✌️")
+        sut?.determineWinner(left: "✌️", right: "✌️")
+        sut?.determineWinner(left: "✌️", right: "✌️")
         
         //then
-        XCTAssertEqual(sut.gameFinished, true)
+        XCTAssertEqual(sut?.gameFinished, true)
     }
     
     func test_determineWinner를_1번_호출하면_gameFinished가_거짓이다() {
         //given, when
-        sut.determineWinner(left: "✌️", right: "✌️")
+        sut?.determineWinner(left: "✌️", right: "✌️")
         
         //then
-        XCTAssertEqual(sut.gameFinished, false)
-        XCTAssertEqual(sut.gameResult, .playing)
+        XCTAssertEqual(sut?.gameFinished, false)
+        XCTAssertEqual(sut?.gameResult, .playing)
     }
     
     func test_determinWinner에서_승리3번_패배0번이면_gameResult가_win타입이다() {
         //given, when
-        sut.determineWinner(left: "✌️", right: "✊")
-        sut.determineWinner(left: "🖐️", right: "✌️")
-        sut.determineWinner(left: "✊", right: "🖐️")
+        sut?.determineWinner(left: "✌️", right: "✊")
+        sut?.determineWinner(left: "🖐️", right: "✌️")
+        sut?.determineWinner(left: "✊", right: "🖐️")
         
         //then
-        XCTAssertEqual(sut.gameResult, .win)
+        XCTAssertEqual(sut?.gameResult, .win)
     }
     
     func test_determinWinner에서_승리0번_패배3번이면_gameResult가_lose타입이다() {
         //given, when
-        sut.determineWinner(left: "🖐️", right: "✊")
-        sut.determineWinner(left: "✊", right: "✌️")
-        sut.determineWinner(left: "✌️", right: "🖐️")
+        sut?.determineWinner(left: "🖐️", right: "✊")
+        sut?.determineWinner(left: "✊", right: "✌️")
+        sut?.determineWinner(left: "✌️", right: "🖐️")
         
         //then
-        XCTAssertEqual(sut.gameResult, .lose)
+        XCTAssertEqual(sut?.gameResult, .lose)
     }
     
     func test_determinWinner에서_무승부이면_gameResult가_draw타입이다() {
         //given, when
-        sut.determineWinner(left: "✊", right: "✊")
-        sut.determineWinner(left: "✌️", right: "✌️")
-        sut.determineWinner(left: "🖐️", right: "🖐️")
+        sut?.determineWinner(left: "✊", right: "✊")
+        sut?.determineWinner(left: "✌️", right: "✌️")
+        sut?.determineWinner(left: "🖐️", right: "🖐️")
         
         //then
-        XCTAssertEqual(sut.gameResult, .draw)
+        XCTAssertEqual(sut?.gameResult, .draw)
     }
     
     //MARK: - 삼세판 끝나고 승패가 갈리면 초기화 하는 기능 TDD
     func test_resetScore를_호출하면_데이터초기화() {
         //given, when
-        sut.determineWinner(left: "✊", right: "✊")
-        sut.determineWinner(left: "✌️", right: "✌️")
-        sut.determineWinner(left: "🖐️", right: "🖐️")
+        sut?.determineWinner(left: "✊", right: "✊")
+        sut?.determineWinner(left: "✌️", right: "✌️")
+        sut?.determineWinner(left: "🖐️", right: "🖐️")
         
         //when
-        sut.resetScore()
+        sut?.resetScore()
         
-        XCTAssertEqual(sut.winCount, 0)
-        XCTAssertEqual(sut.loseCount, 0)
-        XCTAssertEqual(sut.drawCount, 0)
-        XCTAssertEqual(sut.gameResult, .ready)
+        XCTAssertEqual(sut?.winCount, 0)
+        XCTAssertEqual(sut?.loseCount, 0)
+        XCTAssertEqual(sut?.drawCount, 0)
+        XCTAssertEqual(sut?.gameResult, .ready)
     }
     
     

--- a/RockPaperScissors/Score.swift
+++ b/RockPaperScissors/Score.swift
@@ -1,0 +1,57 @@
+//
+//  Score.swift
+//  RockPaperScissors
+//
+//  Created by 김창규 on 2/7/24.
+//
+
+import Foundation
+
+struct Score {
+    private(set) var winCount: Int
+    private(set) var loseCount: Int
+    private(set) var drawCount: Int
+    var limit: Int
+    var counts: [Int] { [winCount, loseCount, drawCount] }
+    var totalScore: Int { counts.reduce(0,+) }
+    
+    var correuntWinlose: String { "\(winCount)승 \(loseCount)패 \(drawCount)무" }
+    
+    var gameResult: GameResult? {
+        var index = 0
+        
+        if totalScore == 0 {
+            index = GameState.GAME_READY
+        } else if totalScore < limit {
+            index = GameState.GAME_PLAYING
+        } else if winCount == loseCount {
+            index = GameState.GAME_DRAW
+        } else if winCount > loseCount {
+            index = GameState.GAME_WIN
+        } else if winCount < loseCount {
+            index = GameState.GAME_LOSE
+        }
+        
+        return GameResult(rawValue: index)
+    }
+}
+
+extension Score {
+    mutating func upWinCount() {
+        self.winCount += 1
+    }
+    
+    mutating func upLoseCount() {
+        self.loseCount += 1
+    }
+    
+    mutating func upDrawCount() {
+        self.drawCount += 1
+    }
+    
+    mutating func resetScore() {
+        self.winCount = 0
+        self.loseCount = 0
+        self.drawCount = 0
+    }
+}

--- a/RockPaperScissors/Score.swift
+++ b/RockPaperScissors/Score.swift
@@ -15,24 +15,24 @@ struct Score {
     var counts: [Int] { [winCount, loseCount, drawCount] }
     var totalScore: Int { counts.reduce(0,+) }
     
-    var correuntWinlose: String { "\(winCount)승 \(loseCount)패 \(drawCount)무" }
+    var currentWinlose: String { "\(winCount)승 \(loseCount)패 \(drawCount)무" }
     
     var gameResult: GameResult? {
         var index = 0
         
         if totalScore == 0 {
-            index = GameState.GAME_READY
+            return .ready
         } else if totalScore < limit {
-            index = GameState.GAME_PLAYING
+            return .playing
         } else if winCount == loseCount {
-            index = GameState.GAME_DRAW
+            return .draw
         } else if winCount > loseCount {
-            index = GameState.GAME_WIN
+            return .win
         } else if winCount < loseCount {
-            index = GameState.GAME_LOSE
+            return .lose
+        } else {
+            return .none
         }
-        
-        return GameResult(rawValue: index)
     }
 }
 


### PR DESCRIPTION
@GREENOVER 
안녕하세요 그린
이번에는 TDD를 진행하면서
이전 STEP에서 배웠던 내용을 적용하였습니다.

이번 STEP에서는 진행하면서  TDD에 큰 어려움은 없었던것 같습니다. (제가 제대로 한거라면...)
TDD를 하다보면서 타입들을 좀 더 적절하게 나누게 되었습니다. 
이 과정에서 생긴 문제점에 대해 조언을 얻고싶습니다.

## 조언을 얻고 싶은 부분
### 프로퍼티의 외부접근 제어

- `HandGame`의 `windCount`,`loseCount`,`drawCount`점수는 이번 요구사항에 중요한 데이터라고 생각해서 외부에서 접근하지 않도록 구현하고 싶었습니다. 처음에 `HandGame` 프로토콜에서 가위바위보 우승자를 결정하는 `determinWinner()`의 결과로 프로토콜에 작성된 `windCount`,`loseCount`,`drawCount`를 업데이트 해주었습니다. 그렇다보니 프로토콜에서는 get, set 둘다 키워드를 작성해두어야 했기 때문에 외부에서 접근해서 변경이 가능한 상태였습니다.
- 그렇다고 `windCount`,`loseCount`,`drawCount`의 set 키워드를 제거하고 서브클래스에서 하나씩 다 구현하기에는 중복코드가 발생하였습니다. 해결 방법으로는`windCount`,`loseCount`,`drawCount`을 가지는 `Score` 구조체타입을 새로 분리하여 `HandGame` 내부에서 사용하게 수정했습니다. `Score`에 mutating이 많아지는 부분 때문에 더 좋은 방법이 없는지 조언을 얻고싶습니다.
      
#### 변경전

<img width="671" alt="2024-02-06_11 35 33" src="https://github.com/yagom-academy/refactoring-rps-game/assets/54075367/73587f7d-69ab-4c30-bf1d-a75b7706ad73">
