### PR TITLE
가위바위보 게임 [STEP 1] honghoker

### DIFF
--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		51304F982BA887A500BBCD8B /* RockPaperScissorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51304F972BA887A500BBCD8B /* RockPaperScissorsTests.swift */; };
+		51304FA12BA88F7000BBCD8B /* RPSGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51304FA02BA88F7000BBCD8B /* RPSGame.swift */; };
+		51304FA32BA8915E00BBCD8B /* Hand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51304FA22BA8915E00BBCD8B /* Hand.swift */; };
 		C784841D2B5E48E300FBF8B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784841C2B5E48E300FBF8B4 /* AppDelegate.swift */; };
 		C784841F2B5E48E300FBF8B4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784841E2B5E48E300FBF8B4 /* SceneDelegate.swift */; };
 		C78484212B5E48E300FBF8B4 /* GameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78484202B5E48E300FBF8B4 /* GameViewController.swift */; };
@@ -30,6 +32,8 @@
 /* Begin PBXFileReference section */
 		51304F952BA887A500BBCD8B /* RockPaperScissorsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RockPaperScissorsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		51304F972BA887A500BBCD8B /* RockPaperScissorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissorsTests.swift; sourceTree = "<group>"; };
+		51304FA02BA88F7000BBCD8B /* RPSGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPSGame.swift; sourceTree = "<group>"; };
+		51304FA22BA8915E00BBCD8B /* Hand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hand.swift; sourceTree = "<group>"; };
 		C78484192B5E48E300FBF8B4 /* RockPaperScissors.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RockPaperScissors.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C784841C2B5E48E300FBF8B4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C784841E2B5E48E300FBF8B4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -92,10 +96,12 @@
 				C784841E2B5E48E300FBF8B4 /* SceneDelegate.swift */,
 				C78484202B5E48E300FBF8B4 /* GameViewController.swift */,
 				C78484632B6A32E500FBF8B4 /* GameView.swift */,
+				51304FA02BA88F7000BBCD8B /* RPSGame.swift */,
 				C78484222B5E48E300FBF8B4 /* Main.storyboard */,
 				C78484252B5E48E400FBF8B4 /* Assets.xcassets */,
 				C78484272B5E48E400FBF8B4 /* LaunchScreen.storyboard */,
 				C784842A2B5E48E400FBF8B4 /* Info.plist */,
+				51304FA22BA8915E00BBCD8B /* Hand.swift */,
 			);
 			path = RockPaperScissors;
 			sourceTree = "<group>";
@@ -210,8 +216,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				C78484212B5E48E300FBF8B4 /* GameViewController.swift in Sources */,
+				51304FA12BA88F7000BBCD8B /* RPSGame.swift in Sources */,
 				C784841D2B5E48E300FBF8B4 /* AppDelegate.swift in Sources */,
 				C78484642B6A32E500FBF8B4 /* GameView.swift in Sources */,
+				51304FA32BA8915E00BBCD8B /* Hand.swift in Sources */,
 				C784841F2B5E48E300FBF8B4 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
+++ b/RockPaperScissors/RockPaperScissors.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		51304F982BA887A500BBCD8B /* RockPaperScissorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51304F972BA887A500BBCD8B /* RockPaperScissorsTests.swift */; };
 		C784841D2B5E48E300FBF8B4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784841C2B5E48E300FBF8B4 /* AppDelegate.swift */; };
 		C784841F2B5E48E300FBF8B4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C784841E2B5E48E300FBF8B4 /* SceneDelegate.swift */; };
 		C78484212B5E48E300FBF8B4 /* GameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78484202B5E48E300FBF8B4 /* GameViewController.swift */; };
@@ -16,7 +17,19 @@
 		C78484642B6A32E500FBF8B4 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78484632B6A32E500FBF8B4 /* GameView.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		51304F992BA887A500BBCD8B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C78484112B5E48E300FBF8B4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C78484182B5E48E300FBF8B4;
+			remoteInfo = RockPaperScissors;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		51304F952BA887A500BBCD8B /* RockPaperScissorsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RockPaperScissorsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		51304F972BA887A500BBCD8B /* RockPaperScissorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RockPaperScissorsTests.swift; sourceTree = "<group>"; };
 		C78484192B5E48E300FBF8B4 /* RockPaperScissors.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RockPaperScissors.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C784841C2B5E48E300FBF8B4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C784841E2B5E48E300FBF8B4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -29,6 +42,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		51304F922BA887A500BBCD8B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C78484162B5E48E300FBF8B4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -39,10 +59,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		51304F962BA887A500BBCD8B /* RockPaperScissorsTests */ = {
+			isa = PBXGroup;
+			children = (
+				51304F972BA887A500BBCD8B /* RockPaperScissorsTests.swift */,
+			);
+			path = RockPaperScissorsTests;
+			sourceTree = "<group>";
+		};
 		C78484102B5E48E300FBF8B4 = {
 			isa = PBXGroup;
 			children = (
 				C784841B2B5E48E300FBF8B4 /* RockPaperScissors */,
+				51304F962BA887A500BBCD8B /* RockPaperScissorsTests */,
 				C784841A2B5E48E300FBF8B4 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -51,6 +80,7 @@
 			isa = PBXGroup;
 			children = (
 				C78484192B5E48E300FBF8B4 /* RockPaperScissors.app */,
+				51304F952BA887A500BBCD8B /* RockPaperScissorsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -73,6 +103,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		51304F942BA887A500BBCD8B /* RockPaperScissorsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 51304F9D2BA887A500BBCD8B /* Build configuration list for PBXNativeTarget "RockPaperScissorsTests" */;
+			buildPhases = (
+				51304F912BA887A500BBCD8B /* Sources */,
+				51304F922BA887A500BBCD8B /* Frameworks */,
+				51304F932BA887A500BBCD8B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				51304F9A2BA887A500BBCD8B /* PBXTargetDependency */,
+			);
+			name = RockPaperScissorsTests;
+			productName = RockPaperScissorsTests;
+			productReference = 51304F952BA887A500BBCD8B /* RockPaperScissorsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C78484182B5E48E300FBF8B4 /* RockPaperScissors */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C784842D2B5E48E400FBF8B4 /* Build configuration list for PBXNativeTarget "RockPaperScissors" */;
@@ -100,6 +148,10 @@
 				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
+					51304F942BA887A500BBCD8B = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = C78484182B5E48E300FBF8B4;
+					};
 					C78484182B5E48E300FBF8B4 = {
 						CreatedOnToolsVersion = 15.0.1;
 					};
@@ -119,11 +171,19 @@
 			projectRoot = "";
 			targets = (
 				C78484182B5E48E300FBF8B4 /* RockPaperScissors */,
+				51304F942BA887A500BBCD8B /* RockPaperScissorsTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		51304F932BA887A500BBCD8B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C78484172B5E48E300FBF8B4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -137,6 +197,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		51304F912BA887A500BBCD8B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				51304F982BA887A500BBCD8B /* RockPaperScissorsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C78484152B5E48E300FBF8B4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -149,6 +217,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		51304F9A2BA887A500BBCD8B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C78484182B5E48E300FBF8B4 /* RockPaperScissors */;
+			targetProxy = 51304F992BA887A500BBCD8B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C78484222B5E48E300FBF8B4 /* Main.storyboard */ = {
@@ -170,6 +246,44 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		51304F9B2BA887A500BBCD8B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6R725M7WWC;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = eunpyo.RockPaperScissorsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RockPaperScissors.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RockPaperScissors";
+			};
+			name = Debug;
+		};
+		51304F9C2BA887A500BBCD8B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6R725M7WWC;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = eunpyo.RockPaperScissorsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RockPaperScissors.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RockPaperScissors";
+			};
+			name = Release;
+		};
 		C784842B2B5E48E400FBF8B4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -344,6 +458,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		51304F9D2BA887A500BBCD8B /* Build configuration list for PBXNativeTarget "RockPaperScissorsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				51304F9B2BA887A500BBCD8B /* Debug */,
+				51304F9C2BA887A500BBCD8B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C78484142B5E48E300FBF8B4 /* Build configuration list for PBXProject "RockPaperScissors" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/RockPaperScissors/RockPaperScissors/GameView.swift
+++ b/RockPaperScissors/RockPaperScissors/GameView.swift
@@ -6,12 +6,6 @@
 
 import UIKit
 
-fileprivate enum Hand {
-    static let paper: String = "🖐️"
-    static let rock: String = "✊"
-    static let scissor: String = "✌️"
-}
-
 class GameView: UIView {
 
     private let computerHandLabel: UILabel = UILabel()
@@ -31,8 +25,8 @@ class GameView: UIView {
     private func initialSetup() {
         backgroundColor = .white
         
-        computerHandLabel.text = Hand.paper
-        userHandLabel.text = Hand.paper
+        computerHandLabel.text = Hand.paper.symbol
+        userHandLabel.text = Hand.paper.symbol
         resultLabel.text = "이겼습니다!"
         currentWinLoseLabel.text = "0승 0무 0패"
         

--- a/RockPaperScissors/RockPaperScissors/Hand.swift
+++ b/RockPaperScissors/RockPaperScissors/Hand.swift
@@ -1,0 +1,38 @@
+//
+//  Hand.swift
+//  RockPaperScissors
+//
+//  Created by 홍은표 on 3/19/24.
+//
+
+import Foundation
+
+protocol HandStrategy {
+  func nextHand() -> Hand
+}
+
+struct RandomHandStrategy: HandStrategy {
+  func nextHand() -> Hand {
+    guard let hand = Hand.allCases.randomElement() else {
+      fatalError("error - hand randomElement()")
+    }
+    return hand
+  }
+}
+
+enum Hand: CaseIterable {
+  case paper
+  case rock
+  case scissor
+  
+  var symbol: String {
+    switch self {
+    case .paper:
+      return "🖐️"
+    case .rock:
+      return "✊"
+    case .scissor:
+      return "✌️"
+    }
+  }
+}

--- a/RockPaperScissors/RockPaperScissors/RPSGame.swift
+++ b/RockPaperScissors/RockPaperScissors/RPSGame.swift
@@ -1,0 +1,128 @@
+//
+//  RPSGame.swift
+//  RockPaperScissors
+//
+//  Created by 홍은표 on 3/19/24.
+//
+
+import Foundation
+
+protocol Scoreable {
+  var wins: Int { get set }
+  var draws: Int { get set }
+  var losses: Int { get set }
+  
+  mutating func reset()
+}
+
+struct Score: Scoreable {
+  var wins: Int = 0
+  var draws: Int = 0
+  var losses: Int = 0
+  
+  mutating func reset() {
+    wins = 0
+    draws = 0
+    losses = 0
+  }
+}
+
+protocol Gamerable: AnyObject {
+  var handStrategy: HandStrategy { get }
+  var currentHand: Hand? { get set }
+  var score: Scoreable { get set }
+  
+  func reset()
+  func next()
+}
+
+extension Gamerable {
+  var isWinner: Bool {
+    score.wins >= 2
+  }
+  
+  var isLoser: Bool {
+    score.losses >= 2
+  }
+  
+  func next() {
+    currentHand = handStrategy.nextHand()
+  }
+  
+  func reset() {
+    score.reset()
+    currentHand = nil
+  }
+}
+
+final class User: Gamerable {
+  var handStrategy: HandStrategy
+  var currentHand: Hand? = nil
+  var score: Scoreable
+  
+  init(handStrategy: HandStrategy, score: Scoreable = Score()) {
+    self.handStrategy = handStrategy
+    self.score = score
+  }
+}
+
+final class Computer: Gamerable {
+  var handStrategy: HandStrategy
+  var currentHand: Hand? = nil
+  var score: Scoreable
+  
+  init(handStrategy: HandStrategy, score: Scoreable = Score()) {
+    self.handStrategy = handStrategy
+    self.score = score
+  }
+}
+
+protocol RPSGameable {
+  var user: Gamerable { get }
+  var computer: Gamerable { get }
+  
+  func battle(userHand: Hand, computerHand: Hand)
+  func playBestOfThree()
+  func reset()
+}
+
+extension RPSGameable {
+  func reset() {
+    user.reset()
+    computer.reset()
+  }
+}
+
+final class RPSGame: RPSGameable {
+  let user: Gamerable
+  let computer: Gamerable
+  
+  init(user: Gamerable, computer: Gamerable) {
+    self.user = user
+    self.computer = computer
+  }
+  
+  func battle(userHand: Hand, computerHand: Hand) {
+    switch (userHand, computerHand) {
+    case let (u, c) where u == c:
+      user.score.draws += 1
+      computer.score.draws += 1
+    case (.paper, .rock), (.rock, .scissor), (.scissor, .paper):
+      user.score.wins += 1
+      computer.score.losses += 1
+    default:
+      user.score.losses += 1
+      computer.score.wins += 1
+    }
+  }
+  
+  func playBestOfThree() {
+    while !user.isWinner && !computer.isWinner {
+      user.next(); computer.next()
+      guard let userHand = user.currentHand, let computerHand = computer.currentHand else {
+        break
+      }
+      battle(userHand: userHand, computerHand: computerHand)
+    }
+  }
+}

--- a/RockPaperScissors/RockPaperScissorsTests/RockPaperScissorsTests.swift
+++ b/RockPaperScissors/RockPaperScissorsTests/RockPaperScissorsTests.swift
@@ -6,30 +6,198 @@
 //
 
 import XCTest
+@testable import RockPaperScissors
 
 final class RockPaperScissorsTests: XCTestCase {
+  
+  var sut: RPSGameable?
+  
+  override func setUpWithError() throws {
+    sut = RPSGame(
+      user: User(handStrategy: RandomHandStrategy()),
+      computer: Computer(handStrategy: RandomHandStrategy())
+    )
+  }
+  
+  override func tearDownWithError() throws {
+    sut = nil
+  }
+  
+  func test_사용자가_가위를_내고_컴퓨터가_가위를_내면_비긴다() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given
+    let user: Hand = .scissor
+    let computer: Hand = .scissor
+    
+    // when
+    sut.battle(userHand: user, computerHand: computer)
+    
+    // then
+    XCTAssert(sut.user.score.draws == 1)
+  }
+  
+  func test_사용자가_바위를_내고_컴퓨터가_바위를_내면_비긴다() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given
+    let user: Hand = .rock
+    let computer: Hand = .rock
+    
+    // when
+    sut.battle(userHand: user, computerHand: computer)
+    
+    // then
+    XCTAssert(sut.user.score.draws == 1)
+  }
+  
+  func test_사용자가_보를_내고_컴퓨터가_보를_내면_비긴다() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given
+    let user: Hand = .paper
+    let computer: Hand = .paper
+    
+    // when
+    sut.battle(userHand: user, computerHand: computer)
+    
+    // then
+    XCTAssert(sut.user.score.draws == 1)
+  }
+  
+  func test_사용자가_가위를_내고_컴퓨터가_보를_내면_이긴다() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given
+    let user: Hand = .scissor
+    let computer: Hand = .paper
+    
+    // when
+    sut.battle(userHand: user, computerHand: computer)
+    
+    // then
+    XCTAssert(sut.user.score.wins == 1)
+  }
+  
+  func test_사용자가_바위를_내고_컴퓨터가_가위를_내면_이긴다() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given
+    let user: Hand = .rock
+    let computer: Hand = .scissor
+    
+    // when
+    sut.battle(userHand: user, computerHand: computer)
+    
+    // then
+    XCTAssert(sut.user.score.wins == 1)
+  }
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
+  func test_사용자가_보를_내고_컴퓨터가_바위를_내면_이긴다() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given
+    let user: Hand = .paper
+    let computer: Hand = .rock
+    
+    // when
+    sut.battle(userHand: user, computerHand: computer)
+    
+    // then
+    XCTAssert(sut.user.score.wins == 1)
+  }
+  
+  func test_사용자가_가위를_내고_컴퓨터가_바위를_내면_진다() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given
+    let user: Hand = .scissor
+    let computer: Hand = .rock
+    
+    // when
+    sut.battle(userHand: user, computerHand: computer)
+    
+    // then
+    XCTAssert(sut.user.score.losses == 1)
+  }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
+  func test_사용자가_바위를_내고_컴퓨터가_보를_내면_진다() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given
+    let user: Hand = .rock
+    let computer: Hand = .paper
+    
+    // when
+    sut.battle(userHand: user, computerHand: computer)
+    
+    // then
+    XCTAssert(sut.user.score.losses == 1)
+  }
+  
+  func test_사용자가_보를_내고_컴퓨터가_가위를_내면_진다() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given
+    let user: Hand = .paper
+    let computer: Hand = .scissor
+    
+    // when
+    sut.battle(userHand: user, computerHand: computer)
+    
+    // then
+    XCTAssert(sut.user.score.losses == 1)
+  }
+  
+  func test_사용자가_삼세판을_이겼을때_승리한다() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given, when
+    sut.battle(userHand: .paper, computerHand: .rock)
+    sut.battle(userHand: .paper, computerHand: .rock)
+    
+    // then
+    XCTAssert(sut.user.isWinner)
+  }
+  
+  func test_사용자가_삼세판을_졌을때_패배한다() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given, when
+    sut.battle(userHand: .scissor, computerHand: .rock)
+    sut.battle(userHand: .rock, computerHand: .scissor)
+    sut.battle(userHand: .scissor, computerHand: .rock)
+    
+    // then
+    XCTAssert(sut.user.isLoser)
+  }
+  
+  func test_삼세판이_끝나면_승패가_갈리는지() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given, when
+    sut.playBestOfThree()
+    
+    // then
+    XCTAssertTrue(sut.user.isWinner || sut.computer.isWinner)
+  }
+  
+  func test_삼세판이_끝나고_승패가_갈리면_초기화() {
+    guard let sut else { return XCTAssertNotNil(sut) }
+    
+    // given, when
+    sut.playBestOfThree()
+    
+    sut.reset()
+    
+    // then
+    XCTAssertNil(sut.user.currentHand)
+    XCTAssertNil(sut.computer.currentHand)
+    XCTAssertEqual(sut.user.score.wins, 0)
+    XCTAssertEqual(sut.user.score.losses, 0)
+    XCTAssertEqual(sut.user.score.draws, 0)
+    XCTAssertEqual(sut.computer.score.wins, 0)
+    XCTAssertEqual(sut.computer.score.losses, 0)
+    XCTAssertEqual(sut.computer.score.draws, 0)
+  }
 }

--- a/RockPaperScissors/RockPaperScissorsTests/RockPaperScissorsTests.swift
+++ b/RockPaperScissors/RockPaperScissorsTests/RockPaperScissorsTests.swift
@@ -1,0 +1,35 @@
+//
+//  RockPaperScissorsTests.swift
+//  RockPaperScissorsTests
+//
+//  Created by 홍은표 on 3/18/24.
+//
+
+import XCTest
+
+final class RockPaperScissorsTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
@ryan-son 
안녕하세요! 벌써 3주차라니 믿기지 않네요.
2주차를 계속 잡고있다간 끝이 없을거 같아 3주차 먼저 진행해서 PR 요청 드립니다 😅
새벽에 올리는거라 무음으로 해두셨길 바라면서.. 조심스레 올려봅니다.

### 미션 요구사항
> TDD의 RED-GREEN-REFACTOR 세 단계를 지켜가며 기능을 구현해봅니다
> UI와의 연동 없이 비지니스 로직만 구현합니다
> 
> 양쪽이 낸 패의 승패 판결을 위한 기능을 TDD로 구현합니다
> 해당 타입, 메서드를 구현해가며 지속적으로 리팩터링 합니다
> 삼세판을 이기면 승리하는 기능을 TDD로 구현합니다
> 삼세판이 끝나고 승패가 갈리면 초기화 하는 기능을 TDD로 구현합니다
> 성능에 유리한 코드로 작성하도록 노력합니다
> 기획의 변경에 대해서 최대한 열린 코드로 작성해봅니다

## 진행하며 느낀 점
이번에 TDD를 처음 접하는데, RED-GREEN-REFACTOR 세 단계를 지키면서 하려니까 생각보다 너무 불편했습니다.
자꾸 평소 버릇처럼 여기저기 튀어나가더라구요. 잠뿐만이 아니라 다른 부분에서 저와의 싸움을 한거같아 재밌었습니다. 

## 고민했던 점
이번에는 폴더링에 신경을 전혀 안쓰고 테스트에만 집중해서 작성해보았습니다. (너무 신경안쓴거 같기도해서 죄송해요 🥲)
기획의 변경에 대해서 최대한 열린 코드로 작성하란게 보여서 유저뿐만이 아니라 컴퓨터도 함께 점수 카운팅을 해주었습니다.

## 조언 부탁드려요!
객체미용체조나 SOLID 를 생각해서 최대한 분리해보려고 했는데, 아쉬운 점이 몇가지 있는거 같아요.

### 승리와 패배 판별
Scoreable은 말 그대로 점수 카운팅만 해주는 역할이므로, 승패를 판단하려면 게임을 하는 플레이어와 관련되어 있는 Gamerable에서 해야한다고 생각해서 현재는 Gamerable protocol의 extension에서 computed 프로퍼티인 isWinner와 isLoser를 통해 승리와 패배를 판별하고 있는데요.
그닥 마음에 안들어서 한참 고민해보았는데 더 좋은 방법이 잘 떠오르지 않습니다. 조금 더 아름다운 방법이 있을지 조언 부탁드립니다!

### 대결 후 점수 카운팅 방법
제일 마음에 안드는 부분입니다!

RPSGame 내부에서 battle 메서드를 통해 결과에 따라 점수를 카운팅해주고 있습니다.
카운팅해주는 값이 직접 지정되어 있기 때문에 별도의 메서드로 분리를 하는게 맞다고 생각하는데, Scoreable 프로토콜에서 정의한 점수 카운팅과 관련된 프로퍼티들이 get set이 둘다 가능하므로 프로토콜 기본 구현체를 통해 별도의 메서드로 분리를 한다고 해도 직접 값을 수정할 수 있기 때문에 의미가 사라지는거 같습니다.
이 부분도 다른 방향이 있을 지 조언 부탁드립니다!